### PR TITLE
opa-react-demo: add RP connect and djblue/portal for DL viewing

### DIFF
--- a/opa-react-demo/connect.yml
+++ b/opa-react-demo/connect.yml
@@ -1,0 +1,20 @@
+input:
+  broker:
+    inputs:
+    - http_server:
+        path: /post/logs
+      processors:
+      - decompress:
+          algorithm: gzip
+      - unarchive:
+          format: json_array
+
+buffer:
+  memory: {}
+
+output:
+  http_client:
+    url: http://portal:5678/submit
+    verb: POST
+    headers:
+      "Content-Type": application/json

--- a/opa-react-demo/docker-compose.yaml
+++ b/opa-react-demo/docker-compose.yaml
@@ -15,8 +15,26 @@ services:
       - --server
       - --addr=:8181
       - --log-level=debug
+      - --config-file=/eopa.yml
       - /policies
     volumes:
       - ./policies:/policies
+      - ./eopa.yml:/eopa.yml
     environment:
       EOPA_LICENSE_KEY: ${EOPA_LICENSE_KEY}
+
+  portal:
+    build: portal
+    ports:
+      - "5678:5678"
+
+  connect:
+    image: docker.redpanda.com/redpandadata/redpanda:latest
+    ports:
+    - "4195:4195"
+    command:
+    - connect
+    - run
+    - /connect.yml
+    volumes:
+    - ./connect.yml:/connect.yml

--- a/opa-react-demo/eopa.yml
+++ b/opa-react-demo/eopa.yml
@@ -1,0 +1,8 @@
+services:
+- name: connect
+  url: http://connect:4195/post
+decision_logs:
+  service: connect
+  reporting:
+    min_delay_seconds: 0
+    max_delay_seconds: 1

--- a/opa-react-demo/portal/Dockerfile
+++ b/opa-react-demo/portal/Dockerfile
@@ -1,0 +1,7 @@
+FROM clojure:tools-deps-bullseye-slim
+WORKDIR /app
+COPY . .
+
+EXPOSE 5678
+# TODO(sr): build at build time, run uberjar here
+ENTRYPOINT ["clj", "-X", "start/run"]

--- a/opa-react-demo/portal/deps.edn
+++ b/opa-react-demo/portal/deps.edn
@@ -1,0 +1,1 @@
+{:deps {djblue/portal {:mvn/version "0.57.0"}}}

--- a/opa-react-demo/portal/src/start.clj
+++ b/opa-react-demo/portal/src/start.clj
@@ -1,0 +1,6 @@
+(ns start
+  (:require [portal.api :as p]))
+
+(defn run [_]
+  (p/start {:port 5678})
+  @(promise))


### PR DESCRIPTION
This introduces an out-of-band web UI for inspecting decision logs. When the services are up, you can view the decision logs via Portal on http://127.0.0.1:5678.

<img width="1474" alt="image" src="https://github.com/user-attachments/assets/263f9182-1f46-4641-9e27-4b828b079784">
