### PR TITLE
opa-react-demo: don't use eopa via /eopa prefix

### DIFF
--- a/opa-react-demo/Caddyfile
+++ b/opa-react-demo/Caddyfile
@@ -1,5 +1,5 @@
 :4000 {
-    handle_path /eopa/* {
+    handle /v1/* {
         reverse_proxy http://eopa:8181
     }
 

--- a/opa-react-demo/docker-compose.yaml
+++ b/opa-react-demo/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
 
   eopa:
     image: ghcr.io/styrainc/enterprise-opa:latest
+    pull_policy: always
     ports:
       - "8181:8181"
     command:

--- a/opa-react-demo/package-lock.json
+++ b/opa-react-demo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "opa-react-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@geist-ui/core": "*",
-        "@geist-ui/react": "*",
+        "@geist-ui/core": "latest",
+        "@geist-ui/react": "latest",
         "@styra/opa-react": "latest",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",

--- a/opa-react-demo/src/BatchDemo.jsx
+++ b/opa-react-demo/src/BatchDemo.jsx
@@ -23,7 +23,7 @@ export default function BatchDemo() {
   const [opaClient] = useState(() => {
     const href = window.location.toString();
     const u = new URL(href); // TODO(sr): better way?!
-    u.pathname = "eopa";
+    u.pathname = "";
     u.search = "";
     return new OPAClient(u.toString());
   });


### PR DESCRIPTION
Previously, the docker-compose setup would have /eopa reverse-proxied to http://eopa:8181; and it worked fine. However, the dev-mode setup, `npm start`, didn't do that, and as a result the batch demo failed if you started `eopa run --server` yourself and used `npm start` to bring the frontend app up.

Now, the docker-compose setup rev-proxies /v1, which is just a normal part of the EOPA API path /v1/batch/data/...

This way, it works fine with the simple "proxy" directive of our package.json.